### PR TITLE
Moved slider above table on mobile.

### DIFF
--- a/sections/ui_overview.R
+++ b/sections/ui_overview.R
@@ -2,28 +2,33 @@ body_overview <- dashboardBody(
   tags$head(
     tags$style(type = "text/css", "#overview_map {height: 48vh !important;}"),
     tags$style(type = 'text/css', ".slider-animate-button { font-size: 20pt !important; }"),
-    tags$style(type = 'text/css', ".slider-animate-container { text-align: left !important; }")
-
+    tags$style(type = 'text/css', ".slider-animate-container { text-align: left !important; }"),
+    tags$style(type = "text/css", "@media (max-width: 991px) { .details { display: flex; flex-direction: column; } }"),
+    tags$style(type = "text/css", "@media (max-width: 991px) { .details .map { order: 1; width: 100%; } }"),
+    tags$style(type = "text/css", "@media (max-width: 991px) { .details .summary { order: 3; width: 100%; } }"),
+    tags$style(type = "text/css", "@media (max-width: 991px) { .details .slider { order: 2; width: 100%; } }")
   ),
   fluidRow(
     fluidRow(
       uiOutput("box_keyFigures")
     ),
     fluidRow(
+      class = "details",
       column(
         box(
           width = 12,
           leafletOutput("overview_map")
         ),
+        class = "map",
         width = 8,
         style = 'padding:0px;'
       ),
       column(
         uiOutput("summaryTables"),
+        class = "summary",
         width = 4,
         style = 'padding:0px;'
-      )),
-    fluidRow(
+      ),
       column(
         sliderInput(
           "timeSlider",
@@ -35,6 +40,7 @@ body_overview <- dashboardBody(
           timeFormat = "%d.%m.%Y",
           animate    = animationOptions(loop = TRUE)
         ),
+        class = "slider",
         width = 12,
         style = 'padding-left:15px; padding-right:15px;'
       )


### PR DESCRIPTION
Shiny currently uses Bootstrap 3.4 which has some limitations with re-ordering (col-*-push/pull-* does not work when more than 12 cells are used for example). To get around this for now, I used flex on large and larger display sizes.

Closes #8 